### PR TITLE
update docs: fix typo, missing comma

### DIFF
--- a/docs/sass-options.md
+++ b/docs/sass-options.md
@@ -8,7 +8,7 @@ module.exports = function(eleventyConfig) {
   eleventyConfig.addPlugin(sass, {
     sass: {
       style: "expanded",
-      sourceMap: true
+      sourceMap: true,
       loadPaths: ["node_modules/bootstrap/scss"],
       includes: "_includes/stylesheets"
     }


### PR DESCRIPTION
I noticed a missing comma in the conf example while following the docs.